### PR TITLE
Declare "dateTextView" and all following declarations on a separate line.

### DIFF
--- a/app/src/main/java/de/tadris/fitness/activity/EnterWorkoutActivity.java
+++ b/app/src/main/java/de/tadris/fitness/activity/EnterWorkoutActivity.java
@@ -46,7 +46,10 @@ import de.tadris.fitness.util.unit.UnitUtils;
 public class EnterWorkoutActivity extends InformationActivity implements SelectWorkoutTypeDialog.WorkoutTypeSelectListener, DatePickerFragment.DatePickerCallback, TimePickerFragment.TimePickerCallback, DurationPickerDialogFragment.DurationPickListener {
 
     WorkoutBuilder workoutBuilder = new WorkoutBuilder();
-    TextView typeTextView, dateTextView, timeTextView, durationTextView;
+    TextView typeTextView;
+    TextView dateTextView;
+    TextView timeTextView;
+    TextView durationTextView;
     EditText distanceEditText, commentEditText;
 
     @Override


### PR DESCRIPTION
**Describe the pull request**
This pull request will address the issue of multiple variables being declared on the same line.

**Link to issue**
[Declare "dateTextView" and all following declarations on a separate line.](https://github.com/smarkandu/FitoTrackW25-Group2-SOEN-6431_2025/issues/16)