### PR TITLE
43 Token Clone - getTileURL() and Zoom Level Methods

### DIFF
--- a/app/src/main/java/de/tadris/fitness/map/tilesource/FitoTrackTileSource.java
+++ b/app/src/main/java/de/tadris/fitness/map/tilesource/FitoTrackTileSource.java
@@ -23,6 +23,9 @@ import org.mapsforge.map.layer.download.tilesource.AbstractTileSource;
 
 public abstract class FitoTrackTileSource extends AbstractTileSource {
 
+    protected static final String PROTOCOL = "https";
+    protected static final int PARALLEL_REQUESTS_LIMIT = 8;
+
     FitoTrackTileSource(String[] hostNames, int port) {
         super(hostNames, port);
         defaultTimeToLive = 8279000;
@@ -34,4 +37,19 @@ public abstract class FitoTrackTileSource extends AbstractTileSource {
     }
 
     public abstract String getName();
+
+
+    public abstract String getTilePath(Tile tile);
+
+    public URL getTileUrl(Tile tile) throws MalformedURLException {
+        return new URL(PROTOCOL, getHostName(), this.port, getTilePath(tile));
+    }
+
+    public byte getZoomLevelMax() {
+        return 18;  // Default value, can be overridden
+    }
+
+    public byte getZoomLevelMin() {
+        return 0;   // Default value
+    }
 }

--- a/app/src/main/java/de/tadris/fitness/map/tilesource/HumanitarianTileSource.java
+++ b/app/src/main/java/de/tadris/fitness/map/tilesource/HumanitarianTileSource.java
@@ -28,10 +28,6 @@ public class HumanitarianTileSource extends FitoTrackTileSource {
 
     public static final HumanitarianTileSource INSTANCE = new HumanitarianTileSource(new String[]{"tile-a.openstreetmap.fr", "tile-b.openstreetmap.fr", "tile-c.openstreetmap.fr"}, 443);
 
-    private static final int PARALLEL_REQUESTS_LIMIT = 8;
-    private static final String PROTOCOL = "https";
-    private static final int ZOOM_LEVEL_MAX = 18;
-    private static final int ZOOM_LEVEL_MIN = 0;
     private static final String NAME = "Humanitarian";
 
     private HumanitarianTileSource(String[] hostNames, int port) {
@@ -49,19 +45,8 @@ public class HumanitarianTileSource extends FitoTrackTileSource {
     }
 
     @Override
-    public URL getTileUrl(Tile tile) throws MalformedURLException {
-
-        return new URL(PROTOCOL, getHostName(), this.port, "/hot/" + tile.zoomLevel + '/' + tile.tileX + '/' + tile.tileY + ".png");
-    }
-
-    @Override
-    public byte getZoomLevelMax() {
-        return ZOOM_LEVEL_MAX;
-    }
-
-    @Override
-    public byte getZoomLevelMin() {
-        return ZOOM_LEVEL_MIN;
+    public String getTilePath(Tile tile) {
+        return "/hot/" + tile.zoomLevel + '/' + tile.tileX + '/' + tile.tileY + ".png";
     }
 
 }

--- a/app/src/main/java/de/tadris/fitness/map/tilesource/MapnikTileSource.java
+++ b/app/src/main/java/de/tadris/fitness/map/tilesource/MapnikTileSource.java
@@ -28,10 +28,7 @@ public class MapnikTileSource extends FitoTrackTileSource {
 
     public static final MapnikTileSource INSTANCE = new MapnikTileSource(new String[]{
             "a.tile.openstreetmap.org", "b.tile.openstreetmap.org", "c.tile.openstreetmap.org"}, 443);
-    private static final int PARALLEL_REQUESTS_LIMIT = 8;
-    private static final String PROTOCOL = "https";
-    private static final int ZOOM_LEVEL_MAX = 19;
-    private static final int ZOOM_LEVEL_MIN = 0;
+
     private static final String NAME = "OSM Mapnik";
 
     private MapnikTileSource(String[] hostNames, int port) {
@@ -49,18 +46,7 @@ public class MapnikTileSource extends FitoTrackTileSource {
     }
 
     @Override
-    public URL getTileUrl(Tile tile) throws MalformedURLException {
-
-        return new URL(PROTOCOL, getHostName(), this.port, "/" + tile.zoomLevel + '/' + tile.tileX + '/' + tile.tileY + ".png");
-    }
-
-    @Override
-    public byte getZoomLevelMax() {
-        return ZOOM_LEVEL_MAX;
-    }
-
-    @Override
-    public byte getZoomLevelMin() {
-        return ZOOM_LEVEL_MIN;
+    public String getTilePath(Tile tile) {
+        return "/" + tile.zoomLevel + '/' + tile.tileX + '/' + tile.tileY + ".png";
     }
 }


### PR DESCRIPTION
**Describe the clone**

"A 14-line clone(43 token clone). The getTileUrl() and getZoomLevelMax() methods are duplicated in HumanitarianTileSource.java and MapnikTileSource.java. Both methods have similar logic but differ in the URL path structure and constants for zoom levels."

---

**Location of the clones**

- Starting at line 54 of /Users/khushipatel/FitoTrackW25-Group2-SOEN-6431_2025/app/src/main/java/de/tadris/fitness/map/tilesource/HumanitarianTileSource.java
- Starting at line 54 of /Users/khushipatel/FitoTrackW25-Group2-SOEN-6431_2025/app/src/main/java/de/tadris/fitness/map/tilesource/MapnikTileSource.java

**Clone Type**
✅ Type 2 Clone

---

**Expected outcome**
The duplicated getTileUrl() and getZoomLevelMax() methods will be refactored into the FitoTrackTileSource base class to avoid code duplication and improve maintainability.

---

**Code before refactoring**

HumanitarianTileSource.java

<img width="906" alt="Image" src="https://github.com/user-attachments/assets/63b3c3c8-1123-4f01-98b7-538f8c3d8688" />


MapTileSource.java

<img width="900" alt="Image" src="https://github.com/user-attachments/assets/013581d1-d798-4636-b196-6b71d90b9ece" />

---

**Code after refactoring**

FitoTrackTileSource.java

<img width="900" alt="Image" src="https://github.com/user-attachments/assets/8ca27be4-e375-4148-acc7-59e6b37a354b" />


HumanitarianTileSource.java

<img width="900" alt="Image" src="https://github.com/user-attachments/assets/3feddb54-ef43-4f3b-8fba-099f566ab23b" />


MapTileSource.java

<img width="900" alt="Image" src="https://github.com/user-attachments/assets/8cb89e12-40d8-45c3-b0aa-ad5c6f065ebb" />