### PR TITLE
Refactor: Centralize home button handling via MenuUtils

### DIFF
--- a/app/src/main/java/de/tadris/fitness/activity/FitoTrackSettingsActivity.java
+++ b/app/src/main/java/de/tadris/fitness/activity/FitoTrackSettingsActivity.java
@@ -145,9 +145,7 @@ public abstract class FitoTrackSettingsActivity extends PreferenceActivity {
 
     @Override
     public boolean onMenuItemSelected(int featureId, MenuItem item) {
-        int id = item.getItemId();
-        if (id == android.R.id.home) {
-            finish();
+        if (MenuUtils.handleHomeButton(this, item)) {
             return true;
         }
         return super.onMenuItemSelected(featureId, item);

--- a/app/src/main/java/de/tadris/fitness/activity/MenuUtils.java
+++ b/app/src/main/java/de/tadris/fitness/activity/MenuUtils.java
@@ -1,0 +1,14 @@
+package de.tadris.fitness.activity;
+
+import android.app.Activity;
+import android.view.MenuItem;
+
+public class MenuUtils {
+    public static boolean handleHomeButton(Activity activity, MenuItem item) {
+        if (item.getItemId() == android.R.id.home) {
+            activity.finish();
+            return true;
+        }
+        return false;
+    }
+}

--- a/app/src/main/java/de/tadris/fitness/activity/WorkoutActivity.java
+++ b/app/src/main/java/de/tadris/fitness/activity/WorkoutActivity.java
@@ -323,9 +323,7 @@ public abstract class WorkoutActivity extends InformationActivity {
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
-        int id = item.getItemId();
-        if (id == android.R.id.home) {
-            finish();
+        if (MenuUtils.handleHomeButton)(this, item)) {
             return true;
         }
         return super.onOptionsItemSelected(item);


### PR DESCRIPTION
refactored the handling of the home button in both WorkoutActivity and FitoTrackSettingsActivity by centralizing the logic into a new utility method (MenuUtils.handleHomeButton). This change removes the duplicated Type 2 clone and improves maintainability. 

Closes #43