### PR TITLE
Replace printStackTrace with secure logging to fix debug vulnerability 

### DIFF
--- a/app/src/main/java/de/tadris/fitness/util/FileUtils.java
+++ b/app/src/main/java/de/tadris/fitness/util/FileUtils.java
@@ -73,8 +73,7 @@ public class FileUtils {
         try {
             Log.d(LOG_TAG_EXPORT, new BufferedInputStream(activity.getContentResolver().openInputStream(uri)).toString());
         } catch (FileNotFoundException e) {
-            e.printStackTrace();
+            Log.e("FileUtils", "Failed to save file", e);
         }
     }
-
 }


### PR DESCRIPTION
### **Description**
A security vulnerability has been identified in the FileUtils.java class where debug logging (Log.d) and exception stack traces (e.printStackTrace()) are present in the code.

---

***Tool Used*** : SonarQube Cloud

---

***link***: https://sonarcloud.io/project/security_hotspots?id=smarkandu_FitoTrackW25-Group2-SOEN-6431_2025&hotspots=AZTIvSKJ7-6Phh-k3-aW

<img width="722" alt="Image" src="https://github.com/user-attachments/assets/02c949e6-2c1a-41e5-a006-1fe29602df74" />

---

### **Location**
`app/src/main/java/de/tadris/fitness/util/FileUtils.java`

---

### **Solution**
- Removed usage of e.printStackTrace() which exposes sensitive stack traces in production.
- Replaced it with Log.e("FileUtils", "Failed to save file", e); for safer and more appropriate error logging.

<img width="1413" alt="Image" src="https://github.com/user-attachments/assets/d02ea872-4d02-4335-aa2e-54e27a3aa411" />