### PR TITLE
Replace printStackTrace with logger to fix debug vulnerability

### DIFF
--- a/app/src/main/java/de/tadris/fitness/activity/SettingsActivity.java
+++ b/app/src/main/java/de/tadris/fitness/activity/SettingsActivity.java
@@ -241,7 +241,7 @@ public class SettingsActivity extends FitoTrackSettingsActivity {
      * @param dialogController The progress dialog controller to be canceled.
      */
     private void handleError(Exception e, ProgressDialogController dialogController) {
-        e.printStackTrace();
+        Log.e("SettingsActivity", "Error during backup/import", e);
         mHandler.post(() -> {
             dialogController.cancel();
             showErrorDialog(e, R.string.error, R.string.errorExportFailed);


### PR DESCRIPTION
### **Description**
A security vulnerability has been identified in the FileUtils.java class where debug logging (Log.d) and exception stack traces (e.printStackTrace()) are present in the code.

---

***Tool Used*** : SonarQube Cloud

---

<img width="1379" alt="Screenshot 2025-04-05 at 3 36 23 PM" src="https://github.com/user-attachments/assets/09ac99cc-d1f0-4c21-8d61-f508cce534c2" />


---

### **Location**
`app/src/main/java/de/tadris/fitness/activity/SettingsActivity.java`

---

### **Solution**
- Removed usage of e.printStackTrace() which exposes sensitive stack traces in production.
- Replaced it with Log.e("SettingsActivity", "Error during backup/import", e); for safer and more appropriate error logging.

<img width="1394" alt="Screenshot 2025-04-05 at 3 43 08 PM" src="https://github.com/user-attachments/assets/7933ce2a-d9d0-4ce7-bd0d-57edc8f8473d" />

