### PR TITLE
Refactor:Removed READ_EXTERNAL_STORAGE since it wasn't necessary

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,7 +27,6 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 


### PR DESCRIPTION
Description

This pull request removes the READ_EXTERNAL_STORAGE permission from AndroidManifest.xml to mitigate potential security and privacy risks, and to comply with modern Android best practices.

Issue

The READ_EXTERNAL_STORAGE permission allows access to all user files on external storage, which can lead to:

Exposure of sensitive user data
Violations of the principle of least privilege
Warnings from tools like SonarCloud regarding unnecessary or dangerous permissions
Additionally, this permission has been deprecated in Android 10+ in favor of Scoped Storage and Storage Access Framework (SAF).

Changes
Removed:
<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />

closing #56 